### PR TITLE
Fix #74 KryptonPage AutoHidden mode size

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
@@ -10,13 +10,14 @@
 // *****************************************************************************
 
 using System;
-using System.Xml;
-using System.Drawing;
-using System.Windows.Forms;
 using System.Collections.Generic;
 using System.ComponentModel;
-using ComponentFactory.Krypton.Workspace;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Xml;
+
 using ComponentFactory.Krypton.Navigator;
+using ComponentFactory.Krypton.Workspace;
 
 namespace ComponentFactory.Krypton.Docking
 {
@@ -279,9 +280,9 @@ namespace ComponentFactory.Krypton.Docking
         }
 
         /// <summary>
-        /// Raises the type specific cell adding event determinated by the derived class.
+        /// Raises the type specific cell adding event determined by the derived class.
         /// </summary>
-        /// <param name="cell">Referecence to new cell being added.</param>
+        /// <param name="cell">Reference to new cell being added.</param>
         protected override void RaiseCellAdding(KryptonWorkspaceCell cell)
         {
             // Generate event so the dockspace cell customization can be performed.
@@ -294,9 +295,9 @@ namespace ComponentFactory.Krypton.Docking
         }
 
         /// <summary>
-        /// Raises the type specific cell removed event determinated by the derived class.
+        /// Raises the type specific cell removed event determined by the derived class.
         /// </summary>
-        /// <param name="cell">Referecence to an existing cell being removed.</param>
+        /// <param name="cell">Reference to an existing cell being removed.</param>
         protected override void RaiseCellRemoved(KryptonWorkspaceCell cell)
         {
             // Generate event so the dockspace cell customization can be reversed.
@@ -482,7 +483,7 @@ namespace ComponentFactory.Krypton.Docking
 
         private void OnDockspaceDropDownClicked(object sender, CancelDropDownEventArgs e)
         {
-            // Generate event so that the appropriate context menu options are preseted and actioned
+            // Generate event so that the appropriate context menu options are presented and actioned
             KryptonDockingManager dockingManager = DockingManager;
             if (dockingManager != null)
             {

--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingEdgeDocked.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingEdgeDocked.cs
@@ -89,7 +89,7 @@ namespace ComponentFactory.Krypton.Docking
         /// <returns>Reference to docking element that handles the new dockspace.</returns>
         public KryptonDockingDockspace AppendDockspace(string name)
         {
-            return CreateAndInsertDockspace(Count, name, new Size(200, 200));
+            return AppendDockspace(name, new Size(200, 200));
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace ComponentFactory.Krypton.Docking
         /// <returns>Reference to docking element that handles the new dockspace.</returns>
         public KryptonDockingDockspace InsertDockspace(int index, string name)
         {
-            return CreateAndInsertDockspace(index, name, new Size(200, 200));
+            return InsertDockspace(index, name, new Size(200, 200));
         }
 
         /// <summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -14,6 +14,7 @@ using System.Xml;
 using System.Drawing;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using ComponentFactory.Krypton.Toolkit;
 using ComponentFactory.Krypton.Workspace;
 using ComponentFactory.Krypton.Navigator;
@@ -70,6 +71,20 @@ namespace ComponentFactory.Krypton.Docking
 
             if (pages != null)
             {
+                Size currentHintSize = SpaceControl.Size;
+                foreach (Size newPageSize in pages.Select(page => page.AutoHiddenSlideSize))
+                {
+                    if (currentHintSize.Width < newPageSize.Width)
+                    {
+                        currentHintSize.Width = newPageSize.Width;
+                    }
+                    if (currentHintSize.Height < newPageSize.Height)
+                    {
+                        currentHintSize.Height = newPageSize.Height;
+                    }
+                }
+
+                SpaceControl.Size = currentHintSize;
                 // If there is no active cell...
                 KryptonWorkspaceCell cell = SpaceControl.ActiveCell;
                 if (cell == null)
@@ -131,6 +146,19 @@ namespace ComponentFactory.Krypton.Docking
             // Append all the pages to end of the cell pages collection
             if (pages != null)
             {
+                Size currentHintSize = SpaceControl.Size;
+                foreach (Size newPageSize in pages.Select(page => page.AutoHiddenSlideSize))
+                {
+                    if (currentHintSize.Width < newPageSize.Width)
+                    {
+                        currentHintSize.Width = newPageSize.Width;
+                    }
+                    if (currentHintSize.Height < newPageSize.Height)
+                    {
+                        currentHintSize.Height = newPageSize.Height;
+                    }
+                }
+                SpaceControl.Size = currentHintSize;
                 cell.Pages.AddRange(pages);
             }
         }
@@ -184,6 +212,19 @@ namespace ComponentFactory.Krypton.Docking
             if (pages != null)
             {
                 // Insert all the pages in sequence starting at the provided index
+                Size currentHintSize = SpaceControl.Size;
+                foreach (Size newPageSize in pages.Select(page => page.AutoHiddenSlideSize))
+                {
+                    if (currentHintSize.Width < newPageSize.Width)
+                    {
+                        currentHintSize.Width = newPageSize.Width;
+                    }
+                    if (currentHintSize.Height < newPageSize.Height)
+                    {
+                        currentHintSize.Height = newPageSize.Height;
+                    }
+                }
+                SpaceControl.Size = currentHintSize;
                 foreach (KryptonPage page in pages)
                 {
                     cell.Pages.Insert(index++, page);

--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.644.0")]
-[assembly: AssemblyFileVersion("5.470.644.0")]
-[assembly: AssemblyInformationalVersion("5.470.644.0")]
+[assembly: AssemblyVersion("5.470.649.0")]
+[assembly: AssemblyFileVersion("5.470.649.0")]
+[assembly: AssemblyInformationalVersion("5.470.649.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Docking")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Docking.dll")]

--- a/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Page/KryptonPage.cs
@@ -821,8 +821,9 @@ namespace ComponentFactory.Krypton.Navigator
         /// <summary>
         /// Gets and sets the preferred size for the page when inside an auto hidden slide panel.
         /// </summary>
-        [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [Category("Appearance")]
+        [Description("When used within a KryptonDockingSpace,\nGive a hint on the Minimum Initial size needed")]
         public virtual Size AutoHiddenSlideSize
         {
             get => _autoHiddenSlideSize;

--- a/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.641.0")]
-[assembly: AssemblyFileVersion("5.470.641.0")]
-[assembly: AssemblyInformationalVersion("5.470.641.0")]
+[assembly: AssemblyVersion("5.470.642.0")]
+[assembly: AssemblyFileVersion("5.470.642.0")]
+[assembly: AssemblyInformationalVersion("5.470.642.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Navigator")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Navigator.dll")]

--- a/Source/Krypton Components/TestApp/Form1.Designer.cs
+++ b/Source/Krypton Components/TestApp/Form1.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues1 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues2 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues3 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues4 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
@@ -38,6 +37,8 @@
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues7 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues8 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues9 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
+            ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues10 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
+            ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues popupPositionValues1 = new ComponentFactory.Krypton.Toolkit.Values.PopupPositionValues();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
             this.kryptonManager1 = new ComponentFactory.Krypton.Toolkit.KryptonManager(this.components);
             this.kryptonPanel1 = new ComponentFactory.Krypton.Toolkit.KryptonPanel();
@@ -52,11 +53,18 @@
             this.kryptonButton2 = new ComponentFactory.Krypton.Toolkit.KryptonButton();
             this.kryptonButton1 = new ComponentFactory.Krypton.Toolkit.KryptonButton();
             this.buttonSpecAny1 = new ComponentFactory.Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonNavigator1 = new ComponentFactory.Krypton.Navigator.KryptonNavigator();
+            this.kryptonPage1 = new ComponentFactory.Krypton.Navigator.KryptonPage();
+            this.kryptonPage2 = new ComponentFactory.Krypton.Navigator.KryptonPage();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel2)).BeginInit();
             this.kryptonPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbThemeCollection)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonNavigator1)).BeginInit();
+            this.kryptonNavigator1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPage1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPage2)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonManager1
@@ -74,6 +82,7 @@
             // 
             // kryptonPanel2
             // 
+            this.kryptonPanel2.Controls.Add(this.kryptonNavigator1);
             this.kryptonPanel2.Controls.Add(this.kbtnApplyTheme);
             this.kryptonPanel2.Controls.Add(this.klbThemes);
             this.kryptonPanel2.Controls.Add(this.kdbThemeCollection);
@@ -100,9 +109,9 @@
             this.kbtnApplyTheme.ToolTipValues.EnableToolTips = true;
             this.kbtnApplyTheme.ToolTipValues.Heading = "Apply Theme";
             this.kbtnApplyTheme.ToolTipValues.Image = global::TestApp.Properties.Resources.Square_Design_32_x_32_New_Green;
-            popupPositionValues1.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues1.PlacementTarget = null;
-            this.kbtnApplyTheme.ToolTipValues.ToolTipPosition = popupPositionValues1;
+            popupPositionValues2.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues2.PlacementTarget = null;
+            this.kbtnApplyTheme.ToolTipValues.ToolTipPosition = popupPositionValues2;
             this.kbtnApplyTheme.Values.Text = "Apply Theme";
             this.kbtnApplyTheme.Click += new System.EventHandler(this.kbtnApplyTheme_Click);
             // 
@@ -113,9 +122,9 @@
             this.klbThemes.Size = new System.Drawing.Size(227, 184);
             this.klbThemes.TabIndex = 9;
             this.klbThemes.ToolTipValues.EnableToolTips = true;
-            popupPositionValues2.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues2.PlacementTarget = null;
-            this.klbThemes.ToolTipValues.ToolTipPosition = popupPositionValues2;
+            popupPositionValues3.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues3.PlacementTarget = null;
+            this.klbThemes.ToolTipValues.ToolTipPosition = popupPositionValues3;
             this.klbThemes.SelectedIndexChanged += new System.EventHandler(this.klbThemes_SelectedIndexChanged);
             // 
             // kdbThemeCollection
@@ -125,9 +134,9 @@
             this.kdbThemeCollection.Size = new System.Drawing.Size(227, 22);
             this.kdbThemeCollection.TabIndex = 8;
             this.kdbThemeCollection.ToolTipValues.EnableToolTips = true;
-            popupPositionValues3.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues3.PlacementTarget = null;
-            this.kdbThemeCollection.ToolTipValues.ToolTipPosition = popupPositionValues3;
+            popupPositionValues4.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues4.PlacementTarget = null;
+            this.kdbThemeCollection.ToolTipValues.ToolTipPosition = popupPositionValues4;
             this.kdbThemeCollection.SelectedItemChanged += new System.EventHandler(this.kdbThemeCollection_SelectedItemChanged);
             // 
             // kcmbThemeCollection
@@ -139,9 +148,9 @@
             this.kcmbThemeCollection.Size = new System.Drawing.Size(305, 21);
             this.kcmbThemeCollection.TabIndex = 6;
             this.kcmbThemeCollection.ToolTipValues.EnableToolTips = true;
-            popupPositionValues4.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues4.PlacementTarget = null;
-            this.kcmbThemeCollection.ToolTipValues.ToolTipPosition = popupPositionValues4;
+            popupPositionValues5.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues5.PlacementTarget = null;
+            this.kcmbThemeCollection.ToolTipValues.ToolTipPosition = popupPositionValues5;
             this.kcmbThemeCollection.SelectedIndexChanged += new System.EventHandler(this.kcmbThemeCollection_SelectedIndexChanged);
             // 
             // kryptonTextBox1
@@ -154,10 +163,10 @@
             this.kryptonTextBox1.ToolTipValues.Description = "Please type carefully -> Right";
             this.kryptonTextBox1.ToolTipValues.EnableToolTips = true;
             this.kryptonTextBox1.ToolTipValues.Heading = "This Text will explode";
-            popupPositionValues5.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Right;
-            popupPositionValues5.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues5.PlacementTarget = null;
-            this.kryptonTextBox1.ToolTipValues.ToolTipPosition = popupPositionValues5;
+            popupPositionValues6.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Right;
+            popupPositionValues6.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues6.PlacementTarget = null;
+            this.kryptonTextBox1.ToolTipValues.ToolTipPosition = popupPositionValues6;
             // 
             // kryptonCheckedListBox1
             // 
@@ -168,10 +177,10 @@
             this.kryptonCheckedListBox1.ToolTipValues.Description = "Description\r\nof\r\nTool\r\ntip\r\nMadness";
             this.kryptonCheckedListBox1.ToolTipValues.EnableToolTips = true;
             this.kryptonCheckedListBox1.ToolTipValues.Heading = "Checked List Box";
-            popupPositionValues6.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Center;
-            popupPositionValues6.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues6.PlacementTarget = null;
-            this.kryptonCheckedListBox1.ToolTipValues.ToolTipPosition = popupPositionValues6;
+            popupPositionValues7.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Center;
+            popupPositionValues7.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues7.PlacementTarget = null;
+            this.kryptonCheckedListBox1.ToolTipValues.ToolTipPosition = popupPositionValues7;
             // 
             // kryptonBorderEdge1
             // 
@@ -183,9 +192,9 @@
             this.kryptonBorderEdge1.ToolTipValues.Description = "Because you can.. -> Bottom";
             this.kryptonBorderEdge1.ToolTipValues.EnableToolTips = true;
             this.kryptonBorderEdge1.ToolTipValues.Heading = "Why";
-            popupPositionValues7.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues7.PlacementTarget = null;
-            this.kryptonBorderEdge1.ToolTipValues.ToolTipPosition = popupPositionValues7;
+            popupPositionValues8.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues8.PlacementTarget = null;
+            this.kryptonBorderEdge1.ToolTipValues.ToolTipPosition = popupPositionValues8;
             // 
             // kryptonButton2
             // 
@@ -198,10 +207,10 @@
             this.kryptonButton2.TabIndex = 1;
             this.kryptonButton2.ToolTipValues.Description = "Description -> Top";
             this.kryptonButton2.ToolTipValues.EnableToolTips = true;
-            popupPositionValues8.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Top;
-            popupPositionValues8.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues8.PlacementTarget = null;
-            this.kryptonButton2.ToolTipValues.ToolTipPosition = popupPositionValues8;
+            popupPositionValues9.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Top;
+            popupPositionValues9.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues9.PlacementTarget = null;
+            this.kryptonButton2.ToolTipValues.ToolTipPosition = popupPositionValues9;
             this.kryptonButton2.ToolTipValues.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.KeyTip;
             this.kryptonButton2.Values.Text = "Test Movement of\r\ntooltip to other \r\ncontrol";
             this.kryptonButton2.Click += new System.EventHandler(this.kryptonButton2_Click);
@@ -214,10 +223,10 @@
             this.kryptonButton1.TabIndex = 0;
             this.kryptonButton1.ToolTipValues.Description = "Description -> Left";
             this.kryptonButton1.ToolTipValues.EnableToolTips = true;
-            popupPositionValues9.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Left;
-            popupPositionValues9.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
-            popupPositionValues9.PlacementTarget = null;
-            this.kryptonButton1.ToolTipValues.ToolTipPosition = popupPositionValues9;
+            popupPositionValues10.PlacementMode = ComponentFactory.Krypton.Toolkit.PlacementMode.Left;
+            popupPositionValues10.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues10.PlacementTarget = null;
+            this.kryptonButton1.ToolTipValues.ToolTipPosition = popupPositionValues10;
             this.kryptonButton1.Values.Text = "Ribbon Test";
             this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
             // 
@@ -229,6 +238,45 @@
             this.buttonSpecAny1.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSpecAny1.ToolTipTitle = "Title";
             this.buttonSpecAny1.UniqueName = "8D0C7B51F6A946484D932C2A06451172";
+            // 
+            // kryptonNavigator1
+            // 
+            this.kryptonNavigator1.Location = new System.Drawing.Point(600, 372);
+            this.kryptonNavigator1.Name = "kryptonNavigator1";
+            this.kryptonNavigator1.Pages.AddRange(new ComponentFactory.Krypton.Navigator.KryptonPage[] {
+            this.kryptonPage1,
+            this.kryptonPage2});
+            this.kryptonNavigator1.SelectedIndex = 0;
+            this.kryptonNavigator1.Size = new System.Drawing.Size(197, 78);
+            this.kryptonNavigator1.TabIndex = 13;
+            this.kryptonNavigator1.Text = "kryptonNavigator1";
+            popupPositionValues1.PlacementRectangle = new System.Drawing.Rectangle(0, 0, 0, 0);
+            popupPositionValues1.PlacementTarget = null;
+            this.kryptonNavigator1.ToolTipValues.ToolTipPosition = popupPositionValues1;
+            // 
+            // kryptonPage1
+            // 
+            this.kryptonPage1.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+            this.kryptonPage1.Flags = 65534;
+            this.kryptonPage1.LastVisibleSet = true;
+            this.kryptonPage1.MinimumSize = new System.Drawing.Size(50, 50);
+            this.kryptonPage1.Name = "kryptonPage1";
+            this.kryptonPage1.Size = new System.Drawing.Size(195, 51);
+            this.kryptonPage1.Text = "kryptonPage1";
+            this.kryptonPage1.ToolTipTitle = "Page ToolTip";
+            this.kryptonPage1.UniqueName = "93558f74a2b4488db9e44dc487858ad7";
+            // 
+            // kryptonPage2
+            // 
+            this.kryptonPage2.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
+            this.kryptonPage2.Flags = 65534;
+            this.kryptonPage2.LastVisibleSet = true;
+            this.kryptonPage2.MinimumSize = new System.Drawing.Size(50, 50);
+            this.kryptonPage2.Name = "kryptonPage2";
+            this.kryptonPage2.Size = new System.Drawing.Size(100, 100);
+            this.kryptonPage2.Text = "kryptonPage2";
+            this.kryptonPage2.ToolTipTitle = "Page ToolTip";
+            this.kryptonPage2.UniqueName = "a0d8f6c733234569bbeca42d3d184119";
             // 
             // Form1
             // 
@@ -251,6 +299,10 @@
             this.kryptonPanel2.ResumeLayout(false);
             this.kryptonPanel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbThemeCollection)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonNavigator1)).EndInit();
+            this.kryptonNavigator1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPage1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPage2)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -269,6 +321,9 @@
         private ComponentFactory.Krypton.Toolkit.KryptonListBox klbThemes;
         private ComponentFactory.Krypton.Toolkit.KryptonDomainUpDown kdbThemeCollection;
         private ComponentFactory.Krypton.Toolkit.KryptonButton kbtnApplyTheme;
+        private ComponentFactory.Krypton.Navigator.KryptonNavigator kryptonNavigator1;
+        private ComponentFactory.Krypton.Navigator.KryptonPage kryptonPage1;
+        private ComponentFactory.Krypton.Navigator.KryptonPage kryptonPage2;
     }
 }
 

--- a/Source/Krypton Components/TestApp/TestApp.csproj
+++ b/Source/Krypton Components/TestApp/TestApp.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
@@ -84,6 +85,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ComponentFactory.Krypton.Navigator\ComponentFactory.Krypton.Navigator 2019.csproj">
+      <Project>{DC0DD714-4D19-4F31-A6D0-EA209D4F0EA8}</Project>
+      <Name>ComponentFactory.Krypton.Navigator 2019</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ComponentFactory.Krypton.Ribbon\ComponentFactory.Krypton.Ribbon 2019.csproj">
       <Project>{E90FC375-453D-4FE4-9822-CE1DB85B6553}</Project>
       <Name>ComponentFactory.Krypton.Ribbon 2019</Name>

--- a/Source/Krypton Docking Examples/Standard Docking/Form1.cs
+++ b/Source/Krypton Docking Examples/Standard Docking/Form1.cs
@@ -43,15 +43,15 @@ namespace StandardDocking
 
         private KryptonPage NewInput()          
         { 
-            return NewPage("Input ", 1, new ContentInput()); 
+            return NewPage("Input ", 1, new ContentInput(), null); 
         }
         
         private KryptonPage NewPropertyGrid()   
         { 
-            return NewPage("Properties ", 2, new ContentPropertyGrid()); 
+            return NewPage("Properties ", 2, new ContentPropertyGrid(), new Size(300, 300)); 
         }
 
-        private KryptonPage NewPage(string name, int image, Control content)
+        private KryptonPage NewPage(string name, int image, Control content, Size ?autoHiddenSizeHint = null)
         {
             // Create new page with title and image
             KryptonPage p = new KryptonPage
@@ -67,6 +67,10 @@ namespace StandardDocking
             p.Controls.Add(content);
 
             _count++;
+            if (autoHiddenSizeHint.HasValue)
+            {
+                p.AutoHiddenSlideSize = autoHiddenSizeHint.Value;
+            }
             return p;
         }
 

--- a/Source/Krypton Docking Examples/Standard Docking/Standard Docking 2019.csproj
+++ b/Source/Krypton Docking Examples/Standard Docking/Standard Docking 2019.csproj
@@ -59,6 +59,21 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Krypton Docking">
+      <HintPath>..\..\..\Bin\Krypton Docking.dll</HintPath>
+    </Reference>
+    <Reference Include="Krypton Navigator">
+      <HintPath>..\..\..\Bin\Krypton Navigator.dll</HintPath>
+    </Reference>
+    <Reference Include="Krypton Ribbon">
+      <HintPath>..\..\..\Bin\Krypton Ribbon.dll</HintPath>
+    </Reference>
+    <Reference Include="Krypton Toolkit">
+      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
+    </Reference>
+    <Reference Include="Krypton Workspace">
+      <HintPath>..\..\..\Bin\Krypton Workspace.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -125,11 +140,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Krypton.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="KryptonToolkitSuite5470">
-      <Version>5.470.770</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Fix #74 KryptonPage AutoHidden mode size
- Allow the Hint Size to be used in the Locking of the object, and also apply to the initial drag location
Allow #83 Add a initial size property for AutoHiddenSlideSize panels in KryptonPage