### PR TITLE
Fixed incorrect type declaration for BITMAPINFO structure

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/ComponentFactory.Krypton.Ribbon 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/ComponentFactory.Krypton.Ribbon 2019.csproj
@@ -54,7 +54,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Krypton Ribbon.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/General/PlatformInvoke.cs
@@ -126,7 +126,7 @@ namespace ComponentFactory.Krypton.Ribbon
         internal static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
 
         [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
-        internal static extern IntPtr CreateDIBSection(IntPtr hDC, BITMAPINFO pBMI, uint iUsage, int ppvBits, IntPtr hSection, uint dwOffset);
+        internal static extern IntPtr CreateDIBSection(IntPtr hDC, ref BITMAPINFO pBMI, uint iUsage, out IntPtr ppvBits, IntPtr hSection, uint dwOffset);
 
         [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
         internal static extern IntPtr CreateCompatibleDC(IntPtr hDC);
@@ -209,7 +209,7 @@ namespace ComponentFactory.Krypton.Ribbon
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal class BITMAPINFO
+        internal struct BITMAPINFO
         {
             public int biSize;
             public int biWidth;

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/View Draw/ViewDrawRibbonContextTitle.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/View Draw/ViewDrawRibbonContextTitle.cs
@@ -448,7 +448,7 @@ namespace ComponentFactory.Krypton.Ribbon
                 bmi.biPlanes = 1;
 
                 // Create a device independant bitmp and select into the memory DC
-                IntPtr hDIB = PI.CreateDIBSection(gDC, bmi, 0, 0, IntPtr.Zero, 0);
+                IntPtr hDIB = PI.CreateDIBSection(gDC, ref bmi, 0, out _, IntPtr.Zero, 0);
                 PI.SelectObject(mDC, hDIB);
 
                 // To call the renderer we need to convert from Win32 HDC to Graphics object

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
@@ -61,7 +61,7 @@
     <CodeAnalysisRules>
     </CodeAnalysisRules>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -1391,7 +1391,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_StartDate="2000/1/1" DocumentXCommentEditorState="&lt;HtmlEditState&gt;&#xA;  &lt;Attributes /&gt;&#xA;&lt;/HtmlEditState&gt;" />
+      <UserProperties DocumentXCommentEditorState="&lt;HtmlEditState&gt;&#xA;  &lt;Attributes /&gt;&#xA;&lt;/HtmlEditState&gt;" BuildVersion_StartDate="2000/1/1" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/PlatformInvoke.cs
@@ -796,7 +796,7 @@ namespace ComponentFactory.Krypton.Toolkit
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal class BITMAPINFO
+        internal struct BITMAPINFO
         {
             public uint biSize;
             public int biWidth;


### PR DESCRIPTION
The BITMAPINFO data type should be a struct, not a class.

I've not done extensive testing on this, but from what I've seen so far, it's fixed the issue described in #142 



