### PR TITLE
Fix #162: Adding a ribbon control to a blank form causes the form tit…

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Docking/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Docking/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.706.0")]
-[assembly: AssemblyFileVersion("5.470.706.0")]
-[assembly: AssemblyInformationalVersion("5.470.706.0")]
+[assembly: AssemblyVersion("5.470.717.0")]
+[assembly: AssemblyFileVersion("5.470.717.0")]
+[assembly: AssemblyInformationalVersion("5.470.717.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Docking")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Docking.dll")]

--- a/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Navigator/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.723.0")]
-[assembly: AssemblyFileVersion("5.470.723.0")]
-[assembly: AssemblyInformationalVersion("5.470.723.0")]
+[assembly: AssemblyVersion("5.470.735.0")]
+[assembly: AssemblyFileVersion("5.470.735.0")]
+[assembly: AssemblyInformationalVersion("5.470.735.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Navigator")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Navigator.dll")]

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -423,12 +423,9 @@ namespace ComponentFactory.Krypton.Ribbon
 
         #region Public Exposed Properties
         /// <summary>
-        /// Gets or sets if the ribbon is allowed to override form chrome by integrating instead with operating system chrome.
         /// </summary>
         [Category("Visuals")]
-        [Description("Is ribbon is allowed to override form chrome by integrating instead with operating system chrome.")]
-        //[DefaultValue(true)]
-        [DefaultValue(false)]
+        [Description("Integrate with operating system chrome instead of Krypton Palette")]
         public bool AllowFormIntegrate
         {
             get => _allowFormIntegrate;
@@ -441,6 +438,20 @@ namespace ComponentFactory.Krypton.Ribbon
                 }
             }
         }
+
+        private bool ShouldSerializeAllowFormIntegrate()
+        {
+            return _allowFormIntegrate;
+        }
+
+        /// <summary>
+        /// Resets the AllowFormIntegrate property to its default value.
+        /// </summary>
+        public void ResetAllowFormIntegrate()
+        {
+            _allowFormIntegrate = false;
+        }
+
 
         /// <summary>
         /// Gets or sets if the user is allowed to change the minimized mode.
@@ -2730,7 +2741,7 @@ namespace ComponentFactory.Krypton.Ribbon
             ShowMinimizeButton = true;
             QATLocation = QATLocation.Above;
             QATUserChange = true;
-            AllowFormIntegrate = true;
+            ResetAllowFormIntegrate();
             LostFocusLosesKeyboard = true;
 
             BackStyle = PaletteBackStyle.PanelClient;

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.764.0")]
-[assembly: AssemblyFileVersion("5.470.764.0")]
-[assembly: AssemblyInformationalVersion("5.470.764.0")]
+[assembly: AssemblyVersion("5.470.780.0")]
+[assembly: AssemblyFileVersion("5.470.780.0")]
+[assembly: AssemblyInformationalVersion("5.470.780.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Ribbon")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Ribbon.dll")]

--- a/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/View Draw/ViewDrawRibbonPanel.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Ribbon/View Draw/ViewDrawRibbonPanel.cs
@@ -66,7 +66,7 @@ namespace ComponentFactory.Krypton.Ribbon
         public override void RenderBefore(RenderContext context)
         {
             // If we are rendering using desktop window composition and using the Office 2010 shape 
-            // of ribbon then we need to draw the tabs area as part of the window chromw
+            // of ribbon then we need to draw the tabs area as part of the window chrome
             if (DrawOnComposition && (_ribbon.RibbonShape == PaletteRibbonShape.Office2010 || _ribbon.RibbonShape == PaletteRibbonShape.Office2013))
             {
                 int tabsHeight = _ribbon.TabsArea.ClientHeight;

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -176,12 +176,12 @@ namespace ComponentFactory.Krypton.Toolkit
                                 InternalGlobalPalette = tempPalette;
 
                                 throw new ArgumentOutOfRangeException(nameof(value),
-                                    "Cannot use palette that would create a circular reference");
+                                    @"Cannot use palette that would create a circular reference");
                             }
                             else
                             {
-                                // Restore the original global pallete as 'SetPalette' will not 
-                                // work correctly unles it still has the old value in place
+                                // Restore the original global palette as 'SetPalette' will not 
+                                // work correctly unless it still has the old value in place
                                 InternalGlobalPalette = tempPalette;
                             }
 

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -308,7 +308,7 @@ namespace ComponentFactory.Krypton.Toolkit
                 set
                 {
                     _hint = value;
-                    if (string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(Hint))
+                    if (string.IsNullOrEmpty(Text) && !string.IsNullOrWhiteSpace(Hint))
                     {
                         PI.SendMessage(Handle, PI.EM_SETCUEBANNER, (IntPtr)1, Hint);
                     }
@@ -579,6 +579,12 @@ namespace ComponentFactory.Krypton.Toolkit
             get => _textBox.Hint;
             set => _textBox.Hint = value;
         }
+
+        private bool ShouldSerializeHint()
+        {
+            return !string.IsNullOrWhiteSpace(Hint);
+        }
+
 
         /// <summary>
         /// </summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.950.0")]
-[assembly: AssemblyFileVersion("5.470.950.0")]
-[assembly: AssemblyInformationalVersion("5.470.950.0")]
+[assembly: AssemblyVersion("5.470.968.0")]
+[assembly: AssemblyFileVersion("5.470.968.0")]
+[assembly: AssemblyInformationalVersion("5.470.968.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Toolkit")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Toolkit.dll")]

--- a/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.680.0")]
-[assembly: AssemblyFileVersion("5.470.680.0")]
-[assembly: AssemblyInformationalVersion("5.470.680.0")]
+[assembly: AssemblyVersion("5.470.691.0")]
+[assembly: AssemblyFileVersion("5.470.691.0")]
+[assembly: AssemblyInformationalVersion("5.470.691.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Workspace")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Workspace.dll")]

--- a/Source/Krypton Explorer/Krypton Explorer 2019.csproj
+++ b/Source/Krypton Explorer/Krypton Explorer 2019.csproj
@@ -63,12 +63,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Krypton Navigator">
       <HintPath>..\..\Bin\Krypton Navigator.dll</HintPath>
     </Reference>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Krypton Toolkit">
       <HintPath>..\..\Bin\Krypton Toolkit.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/Source/Krypton Ribbon Examples/Application Menu/Application Menu 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Application Menu/Application Menu 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
@@ -86,7 +86,6 @@ namespace ApplicationMenu
             // 
             // kryptonRibbon1
             // 
-            this.kryptonRibbon1.AllowFormIntegrate = true;
             this.kryptonRibbon1.InDesignHelperMode = true;
             this.kryptonRibbon1.Name = "kryptonRibbon1";
             this.kryptonRibbon1.RibbonAppButton.AppButtonMenuItems.AddRange(new ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemBase[] {
@@ -105,7 +104,6 @@ namespace ApplicationMenu
             this.kryptonRibbon1.RibbonAppButton.AppButtonSpecs.AddRange(new ComponentFactory.Krypton.Ribbon.ButtonSpecAppMenu[] {
             this.buttonSpecAppMenu1,
             this.buttonSpecAppMenu2});
-            this.kryptonRibbon1.RibbonAppButton.AppButtonToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.kryptonRibbon1.RibbonTabs.AddRange(new ComponentFactory.Krypton.Ribbon.KryptonRibbonTab[] {
             this.kryptonRibbonTab1});
             this.kryptonRibbon1.SelectedContext = null;
@@ -159,16 +157,12 @@ namespace ApplicationMenu
             // 
             this.buttonSpecAppMenu1.Style = ComponentFactory.Krypton.Toolkit.PaletteButtonStyle.Standalone;
             this.buttonSpecAppMenu1.Text = "O&ptions";
-            this.buttonSpecAppMenu1.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.ToolTip;
-            this.buttonSpecAppMenu1.Type = ComponentFactory.Krypton.Toolkit.PaletteButtonSpecStyle.Generic;
             this.buttonSpecAppMenu1.UniqueName = "9664A073DF8541B79664A073DF8541B7";
             // 
             // buttonSpecAppMenu2
             // 
             this.buttonSpecAppMenu2.Style = ComponentFactory.Krypton.Toolkit.PaletteButtonStyle.Standalone;
             this.buttonSpecAppMenu2.Text = "&Close";
-            this.buttonSpecAppMenu2.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.ToolTip;
-            this.buttonSpecAppMenu2.Type = ComponentFactory.Krypton.Toolkit.PaletteButtonSpecStyle.Generic;
             this.buttonSpecAppMenu2.UniqueName = "70F15DC834C14B3070F15DC834C14B30";
             // 
             // kryptonRibbonTab1
@@ -204,7 +198,6 @@ namespace ApplicationMenu
             this.button2010Blue.ImageSmall = ((System.Drawing.Image)(resources.GetObject("button2010Blue.ImageSmall")));
             this.button2010Blue.TextLine1 = "2010";
             this.button2010Blue.TextLine2 = "Blue";
-            this.button2010Blue.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.button2010Blue.Click += new System.EventHandler(this.button2010Blue_Click);
             // 
             // button2010Silver
@@ -214,7 +207,6 @@ namespace ApplicationMenu
             this.button2010Silver.ImageSmall = ((System.Drawing.Image)(resources.GetObject("button2010Silver.ImageSmall")));
             this.button2010Silver.TextLine1 = "2010";
             this.button2010Silver.TextLine2 = "Silver";
-            this.button2010Silver.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.button2010Silver.Click += new System.EventHandler(this.button2010Silver_Click);
             // 
             // button2010Black
@@ -224,7 +216,6 @@ namespace ApplicationMenu
             this.button2010Black.ImageSmall = ((System.Drawing.Image)(resources.GetObject("button2010Black.ImageSmall")));
             this.button2010Black.TextLine1 = "2010";
             this.button2010Black.TextLine2 = "Black";
-            this.button2010Black.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.button2010Black.Click += new System.EventHandler(this.button2010Black_Click);
             // 
             // kryptonRibbonGroupTriple1
@@ -242,7 +233,6 @@ namespace ApplicationMenu
             this.buttonBlue.ImageSmall = ((System.Drawing.Image)(resources.GetObject("buttonBlue.ImageSmall")));
             this.buttonBlue.TextLine1 = "2007";
             this.buttonBlue.TextLine2 = "Blue";
-            this.buttonBlue.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonBlue.Click += new System.EventHandler(this.buttonBlue_Click);
             // 
             // buttonSilver
@@ -253,7 +243,6 @@ namespace ApplicationMenu
             this.buttonSilver.KeyTip = "S";
             this.buttonSilver.TextLine1 = "2007";
             this.buttonSilver.TextLine2 = "Silver";
-            this.buttonSilver.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSilver.Click += new System.EventHandler(this.buttonSilver_Click);
             // 
             // buttonBlack
@@ -264,7 +253,6 @@ namespace ApplicationMenu
             this.buttonBlack.KeyTip = "L";
             this.buttonBlack.TextLine1 = "2007";
             this.buttonBlack.TextLine2 = "Black";
-            this.buttonBlack.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonBlack.Click += new System.EventHandler(this.buttonBlack_Click);
             // 
             // kryptonRibbonGroupTriple3
@@ -282,7 +270,6 @@ namespace ApplicationMenu
             this.buttonSparkleBlue.KeyTip = "E";
             this.buttonSparkleBlue.TextLine1 = "Sparkle";
             this.buttonSparkleBlue.TextLine2 = "Blue";
-            this.buttonSparkleBlue.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSparkleBlue.Click += new System.EventHandler(this.buttonSparkleBlue_Click);
             // 
             // buttonSparkleOrange
@@ -293,7 +280,6 @@ namespace ApplicationMenu
             this.buttonSparkleOrange.KeyTip = "O";
             this.buttonSparkleOrange.TextLine1 = "Sparkle";
             this.buttonSparkleOrange.TextLine2 = "Orange";
-            this.buttonSparkleOrange.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSparkleOrange.Click += new System.EventHandler(this.buttonSparkleOrange_Click);
             // 
             // buttonSparklePurple
@@ -304,7 +290,6 @@ namespace ApplicationMenu
             this.buttonSparklePurple.KeyTip = "P";
             this.buttonSparklePurple.TextLine1 = "Sparkle";
             this.buttonSparklePurple.TextLine2 = "Purple";
-            this.buttonSparklePurple.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSparklePurple.Click += new System.EventHandler(this.buttonSparklePurple_Click);
             // 
             // kryptonRibbonGroupTriple2
@@ -320,7 +305,6 @@ namespace ApplicationMenu
             this.button2003.ImageSmall = ((System.Drawing.Image)(resources.GetObject("button2003.ImageSmall")));
             this.button2003.KeyTip = "3";
             this.button2003.TextLine1 = " 2003";
-            this.button2003.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.button2003.Click += new System.EventHandler(this.button2003_Click);
             // 
             // buttonSystem
@@ -330,12 +314,7 @@ namespace ApplicationMenu
             this.buttonSystem.ImageSmall = ((System.Drawing.Image)(resources.GetObject("buttonSystem.ImageSmall")));
             this.buttonSystem.KeyTip = "S";
             this.buttonSystem.TextLine1 = "System";
-            this.buttonSystem.ToolTipStyle = ComponentFactory.Krypton.Toolkit.LabelStyle.SuperTip;
             this.buttonSystem.Click += new System.EventHandler(this.buttonSystem_Click);
-            // 
-            // kryptonManager1
-            // 
-            this.kryptonManager1.GlobalPaletteMode = ComponentFactory.Krypton.Toolkit.PaletteModeManager.Office2010Silver;
             // 
             // kryptonPanel1
             // 
@@ -400,7 +379,7 @@ namespace ApplicationMenu
             // 
             this.textBoxMinHeight.Location = new System.Drawing.Point(163, 98);
             this.textBoxMinHeight.Name = "textBoxMinHeight";
-            this.textBoxMinHeight.Size = new System.Drawing.Size(50, 23);
+            this.textBoxMinHeight.Size = new System.Drawing.Size(50, 20);
             this.textBoxMinHeight.TabIndex = 6;
             this.textBoxMinHeight.Text = "kryptonTextBox3";
             // 
@@ -408,7 +387,7 @@ namespace ApplicationMenu
             // 
             this.textBoxDocsTitle.Location = new System.Drawing.Point(163, 50);
             this.textBoxDocsTitle.Name = "textBoxDocsTitle";
-            this.textBoxDocsTitle.Size = new System.Drawing.Size(141, 23);
+            this.textBoxDocsTitle.Size = new System.Drawing.Size(141, 20);
             this.textBoxDocsTitle.TabIndex = 1;
             this.textBoxDocsTitle.Text = "kryptonTextBox1";
             // 
@@ -443,7 +422,7 @@ namespace ApplicationMenu
             // 
             this.textBoxMinWidth.Location = new System.Drawing.Point(163, 74);
             this.textBoxMinWidth.Name = "textBoxMinWidth";
-            this.textBoxMinWidth.Size = new System.Drawing.Size(50, 23);
+            this.textBoxMinWidth.Size = new System.Drawing.Size(50, 20);
             this.textBoxMinWidth.TabIndex = 3;
             this.textBoxMinWidth.Text = "kryptonTextBox2";
             // 

--- a/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Auto Shrinking Groups 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Auto Shrinking Groups 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Contextual Tabs/Contextual Tabs 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Contextual Tabs/Contextual Tabs 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/KeyTips + Keyboard Access 2019.csproj
+++ b/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/KeyTips + Keyboard Access 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/KryptonGallery Examples/KryptonGallery Examples 2019.csproj
+++ b/Source/Krypton Ribbon Examples/KryptonGallery Examples/KryptonGallery Examples 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/MDI Ribbon/MDI Ribbon 2019.csproj
+++ b/Source/Krypton Ribbon Examples/MDI Ribbon/MDI Ribbon 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Quick Access Toolbar/Quick Access Toolbar 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Quick Access Toolbar/Quick Access Toolbar 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Ribbon + Navigator + Workspace 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Ribbon + Navigator + Workspace 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Ribbon Gallery/Ribbon Gallery 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon Gallery/Ribbon Gallery 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Ribbon Examples/Ribbon ToolTips/Ribbon ToolTips 2019.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon ToolTips/Ribbon ToolTips 2019.csproj
@@ -54,6 +54,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Ribbon, Version=5.470.715.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Advanced Page Drag + Drop/Advanced Page Drag + Drop 2019.csproj
+++ b/Source/Krypton Workspace Examples/Advanced Page Drag + Drop/Advanced Page Drag + Drop 2019.csproj
@@ -56,6 +56,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Basic Page Drag + Drop/Basic Page Drag + Drop 2019.csproj
+++ b/Source/Krypton Workspace Examples/Basic Page Drag + Drop/Basic Page Drag + Drop 2019.csproj
@@ -56,6 +56,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Cell Maximize + Restore/Cell Maximize + Restore 2019.csproj
+++ b/Source/Krypton Workspace Examples/Cell Maximize + Restore/Cell Maximize + Restore 2019.csproj
@@ -56,6 +56,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Memo Editor/Form1.cs
+++ b/Source/Krypton Workspace Examples/Memo Editor/Form1.cs
@@ -84,9 +84,9 @@ namespace MemoEditor
                 try
                 {
                     // Restore the global palette selected previously
-                    string globalPalette = memoEditorSettings.GetValue("GlobalPalette") as string;
-                    if (!string.IsNullOrEmpty(globalPalette))
-                        kryptonManager.GlobalPaletteMode = (PaletteModeManager)Enum.Parse(typeof(PaletteModeManager), globalPalette);
+                    //string globalPalette = memoEditorSettings.GetValue("GlobalPalette") as string;
+                    //if (!string.IsNullOrEmpty(globalPalette))
+                    //    kryptonManager.GlobalPaletteMode = (PaletteModeManager)Enum.Parse(typeof(PaletteModeManager), globalPalette);
 
                     // Restore the cell mode selected previously
                     string cellMode = memoEditorSettings.GetValue("CellMode") as string;

--- a/Source/Krypton Workspace Examples/Memo Editor/Memo Editor 2019.csproj
+++ b/Source/Krypton Workspace Examples/Memo Editor/Memo Editor 2019.csproj
@@ -57,6 +57,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Workspace Cell Layout/Workspace Cell Layout 2019.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Cell Layout/Workspace Cell Layout 2019.csproj
@@ -56,6 +56,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Workspace Cell Modes/Workspace Cell Modes 2019.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Cell Modes/Workspace Cell Modes 2019.csproj
@@ -56,6 +56,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Krypton Workspace Examples/Workspace Persistence/Workspace Persistence 2019.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Persistence/Workspace Persistence 2019.csproj
@@ -57,6 +57,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Krypton Navigator, Version=5.470.673.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e" />
     <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">


### PR DESCRIPTION
…le bar to always be blue (system accent) when selected.

- Change the description to match what the value is asking for
- Make sure the default is serialised when needed
= `[Description("Integrate with operating system chrome instead of Krypton Palette")]`
- Add `<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>` to some projects