### PR TITLE
Fix #167 : KryptonContextMenu in KryptonTreeView is not obvious and not designer friendly 

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -174,13 +174,15 @@ namespace ComponentFactory.Krypton.Toolkit
         #endregion
 
         #region Public
-        /// <summary>
-        /// Gets or sets the ContextMenuStrip associated with this control.
-        /// </summary>
+        /// <summary>Gets or sets the <see cref="T:System.Windows.Forms.ContextMenuStrip" /> associated with this control.</summary>
+        /// <returns>The <see cref="T:System.Windows.Forms.ContextMenuStrip" /> for this control, or <see langword="null" /> if there is no <see cref="T:System.Windows.Forms.ContextMenuStrip" />. The default is <see langword="null" />.</returns>
+        [Category("Behavior")]
+        [Description("Consider using KryptonContextMenu within the behaviors section.\nThe Winforms shortcut menu to show when the user right-clicks the page.\nNote: The ContextMenu will be rendered.")]
+        [DefaultValue(null)]
         public override ContextMenuStrip ContextMenuStrip
         {
             [DebuggerStepThrough]
-            get { return base.ContextMenuStrip; }
+            get => base.ContextMenuStrip;
 
             set 
             { 
@@ -202,6 +204,7 @@ namespace ComponentFactory.Krypton.Toolkit
                 }
             }
         }
+
 
         /// <summary>
         /// Gets and sets the KryptonContextMenu to show when right clicked.
@@ -284,7 +287,7 @@ namespace ComponentFactory.Krypton.Toolkit
         public PaletteMode PaletteMode
         {
             [DebuggerStepThrough]
-            get { return _paletteMode; }
+            get => _paletteMode;
 
             set
             {
@@ -338,7 +341,7 @@ namespace ComponentFactory.Krypton.Toolkit
         public IPalette Palette
         {
             [DebuggerStepThrough]
-            get { return _localPalette; }
+            get => _localPalette;
 
             set
             {
@@ -1183,7 +1186,7 @@ namespace ComponentFactory.Krypton.Toolkit
                     // Extract the screen mouse position (if might not actually be provided)
                     Point mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
 
-                    // If keyboard activated, the menu position is centred
+                    // If keyboard activated, the menu position is centered
                     if (((int)((long)m.LParam)) == -1)
                     {
                         mousePt = new Point(Width / 2, Height / 2);

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.968.0")]
-[assembly: AssemblyFileVersion("5.470.968.0")]
-[assembly: AssemblyInformationalVersion("5.470.968.0")]
+[assembly: AssemblyVersion("5.470.973.0")]
+[assembly: AssemblyFileVersion("5.470.973.0")]
+[assembly: AssemblyInformationalVersion("5.470.973.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Toolkit")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Toolkit.dll")]

--- a/Source/Krypton Toolkit Examples/Krypton Toolkit Examples II 2019.sln
+++ b/Source/Krypton Toolkit Examples/Krypton Toolkit Examples II 2019.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KryptonTreeView Examples 2019", "KryptonTreeView Examples\KryptonTreeView Examples 2019.csproj", "{F52C6F54-67E8-4713-85DD-1E05116CCDB8}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test MessageBox Clipping 2019", "Test MessageBox Clipping\Test MessageBox Clipping 2019.csproj", "{5F031B1D-9C9F-495E-9B77-BC6E4913D010}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SystemThemedForms 2019", "SystemThemedForms\SystemThemedForms 2019.csproj", "{AC741E98-AA1D-4167-BCC4-16FE7A029D66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentFactory.Krypton.Toolkit 2019", "..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj", "{96ECAECC-54F8-4AA5-8591-B443C2D9565F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,18 @@ Global
 		{AC741E98-AA1D-4167-BCC4-16FE7A029D66}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{AC741E98-AA1D-4167-BCC4-16FE7A029D66}.Release|x86.ActiveCfg = Release|Any CPU
 		{AC741E98-AA1D-4167-BCC4-16FE7A029D66}.Release|x86.Build.0 = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Debug|x86.Build.0 = Debug|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|x86.ActiveCfg = Release|Any CPU
+		{96ECAECC-54F8-4AA5-8591-B443C2D9565F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.Designer.cs
@@ -34,7 +34,22 @@
             this.groupBox = new System.Windows.Forms.GroupBox();
             this.propertyGrid = new System.Windows.Forms.PropertyGrid();
             this.kryptonTreeView = new ComponentFactory.Krypton.Toolkit.KryptonTreeView();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripComboBox1 = new System.Windows.Forms.ToolStripComboBox();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.imageList = new System.Windows.Forms.ImageList(this.components);
+            this.kryptonContextMenu1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenu();
+            this.kryptonContextMenuHeading1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuHeading();
+            this.kryptonContextMenuItems1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuItems();
+            this.kryptonContextMenuItem1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonContextMenuCheckBox1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuCheckBox();
+            this.kryptonContextMenuCheckButton1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuCheckButton();
+            this.kryptonContextMenuRadioButton1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuRadioButton();
+            this.kryptonContextMenuLinkLabel1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuLinkLabel();
+            this.kryptonContextMenuColorColumns1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuColorColumns();
+            this.kryptonContextMenuImageSelect1 = new ComponentFactory.Krypton.Toolkit.KryptonContextMenuImageSelect();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.checkSystem = new ComponentFactory.Krypton.Toolkit.KryptonCheckButton();
             this.checkSparkle = new ComponentFactory.Krypton.Toolkit.KryptonCheckButton();
@@ -47,6 +62,7 @@
             this.kryptonManager1 = new ComponentFactory.Krypton.Toolkit.KryptonManager(this.components);
             this.kryptonCheckSet = new ComponentFactory.Krypton.Toolkit.KryptonCheckSet(this.components);
             this.groupBox.SuspendLayout();
+            this.contextMenuStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonCheckSet)).BeginInit();
             this.SuspendLayout();
@@ -90,11 +106,44 @@
             this.kryptonTreeView.HotTracking = true;
             this.kryptonTreeView.ImageIndex = 3;
             this.kryptonTreeView.ImageList = this.imageList;
+            this.kryptonTreeView.KryptonContextMenu = this.kryptonContextMenu1;
             this.kryptonTreeView.Location = new System.Drawing.Point(13, 31);
             this.kryptonTreeView.Name = "kryptonTreeView";
             this.kryptonTreeView.SelectedImageIndex = 3;
             this.kryptonTreeView.Size = new System.Drawing.Size(255, 259);
             this.kryptonTreeView.TabIndex = 6;
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem1,
+            this.toolStripComboBox1,
+            this.toolStripSeparator1,
+            this.toolStripSeparator2});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(182, 65);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(181, 22);
+            this.toolStripMenuItem1.Text = "toolStripMenuItem1";
+            // 
+            // toolStripComboBox1
+            // 
+            this.toolStripComboBox1.Name = "toolStripComboBox1";
+            this.toolStripComboBox1.Size = new System.Drawing.Size(121, 23);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(178, 6);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(178, 6);
             // 
             // imageList
             // 
@@ -108,6 +157,47 @@
             this.imageList.Images.SetKeyName(5, "flag_greece.png");
             this.imageList.Images.SetKeyName(6, "flag_netherlands.png");
             this.imageList.Images.SetKeyName(7, "flag_poland.png");
+            // 
+            // kryptonContextMenu1
+            // 
+            this.kryptonContextMenu1.Items.AddRange(new ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemBase[] {
+            this.kryptonContextMenuHeading1,
+            this.kryptonContextMenuItems1,
+            this.kryptonContextMenuCheckBox1,
+            this.kryptonContextMenuCheckButton1,
+            this.kryptonContextMenuRadioButton1,
+            this.kryptonContextMenuLinkLabel1,
+            this.kryptonContextMenuColorColumns1,
+            this.kryptonContextMenuImageSelect1});
+            // 
+            // kryptonContextMenuHeading1
+            // 
+            this.kryptonContextMenuHeading1.ExtraText = "";
+            // 
+            // kryptonContextMenuItems1
+            // 
+            this.kryptonContextMenuItems1.Items.AddRange(new ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemBase[] {
+            this.kryptonContextMenuItem1});
+            // 
+            // kryptonContextMenuItem1
+            // 
+            this.kryptonContextMenuItem1.Text = "Menu Item";
+            // 
+            // kryptonContextMenuCheckBox1
+            // 
+            this.kryptonContextMenuCheckBox1.ExtraText = "";
+            // 
+            // kryptonContextMenuCheckButton1
+            // 
+            this.kryptonContextMenuCheckButton1.Text = "CheckButton";
+            // 
+            // kryptonContextMenuRadioButton1
+            // 
+            this.kryptonContextMenuRadioButton1.ExtraText = "";
+            // 
+            // kryptonContextMenuLinkLabel1
+            // 
+            this.kryptonContextMenuLinkLabel1.ExtraText = "";
             // 
             // groupBox1
             // 
@@ -203,10 +293,6 @@
             this.buttonRemove.Values.Text = "Remove";
             this.buttonRemove.Click += new System.EventHandler(this.buttonRemove_Click);
             // 
-            // kryptonManager1
-            // 
-            this.kryptonManager1.GlobalPaletteMode = ComponentFactory.Krypton.Toolkit.PaletteModeManager.Office2010Blue;
-            // 
             // kryptonCheckSet
             // 
             this.kryptonCheckSet.CheckButtons.Add(this.checkSystem);
@@ -232,6 +318,7 @@
             this.Name = "Form1";
             this.Text = "KryptonTreeView Examples";
             this.groupBox.ResumeLayout(false);
+            this.contextMenuStrip1.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonCheckSet)).EndInit();
@@ -257,6 +344,21 @@
         private ComponentFactory.Krypton.Toolkit.KryptonManager kryptonManager1;
         private ComponentFactory.Krypton.Toolkit.KryptonCheckSet kryptonCheckSet;
         private System.Windows.Forms.ImageList imageList;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenu kryptonContextMenu1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuHeading kryptonContextMenuHeading1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuItems kryptonContextMenuItems1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuCheckBox kryptonContextMenuCheckBox1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuCheckButton kryptonContextMenuCheckButton1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuRadioButton kryptonContextMenuRadioButton1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuLinkLabel kryptonContextMenuLinkLabel1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuColorColumns kryptonContextMenuColorColumns1;
+        private ComponentFactory.Krypton.Toolkit.KryptonContextMenuImageSelect kryptonContextMenuImageSelect1;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripComboBox toolStripComboBox1;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
     }
 }
 

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.cs
@@ -1,10 +1,18 @@
-﻿using System;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
+
 using ComponentFactory.Krypton.Toolkit;
 
 namespace KryptonTreeViewExamples
 {
-    public partial class Form1 : Form
+    public partial class Form1 : KryptonForm
     {
         private int _next = 1;
         private Random _rand = new Random();
@@ -33,7 +41,7 @@ namespace KryptonTreeViewExamples
         {
             KryptonTreeNode item = new KryptonTreeNode
             {
-                Text = "Item " + (_next++).ToString(),
+                Text = $"Item {(_next++)}",
                 ImageIndex = _rand.Next(imageList.Images.Count - 1)
             };
             item.SelectedImageIndex = item.ImageIndex;

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.resx
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.resx
@@ -125,7 +125,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABA
-        GAAAAk1TRnQBSQFMAgEBCAEAAUgBAAFIAQABEAEAARABAAT/AREBAAj/AUIBTQE2BwABNgMAASgDAAFA
+        GAAAAk1TRnQBSQFMAgEBCAEAAWgBAAFoAQABEAEAARABAAT/AREBAAj/AUIBTQE2BwABNgMAASgDAAFA
         AwABMAMAAQEBAAEQBgABGP8A/wD/AP8A/wD/AP8A/wD/ABsAAdIBLQEwAQkBMAENAVEBDQFRAQ0B0gEt
         AZQBUgGUAVIBlAFSAbUBUgFJAU0BQAFIAUEBSAFBAUwBQQFMAeYBTAGQASUBzgEEAe4BCAHvAQgBDwEJ
         AQ8BCQEwAQ0BUQENAVEBEQFyAREBkgERAZMBFQGzARUBtAEVAdUBGQEVASoBLQEZAS4BGQFOARkBTgEZ
@@ -231,6 +231,12 @@
         ATADAAEBAQABAQUAAYABARYAA/+BABD/YAAg/2AAEP8L
 </value>
   </data>
+  <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>413, 17</value>
+  </metadata>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>587, 17</value>
+  </metadata>
   <metadata name="kryptonManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/KryptonTreeView Examples 2019.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/KryptonTreeView Examples 2019.csproj
@@ -43,10 +43,6 @@
     <ApplicationIcon>Krypton.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -86,6 +82,12 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Krypton.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj">
+      <Project>{96ecaecc-54f8-4aa5-8591-b443c2d9565f}</Project>
+      <Name>ComponentFactory.Krypton.Toolkit 2019</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Program.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Program.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
 
 namespace KryptonTreeViewExamples

--- a/Source/Krypton Toolkit Examples/SystemThemedForms/Form1.cs
+++ b/Source/Krypton Toolkit Examples/SystemThemedForms/Form1.cs
@@ -1,5 +1,13 @@
-﻿using System;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Drawing;
+
 using ComponentFactory.Krypton.Toolkit;
 
 namespace SystemThemedForms

--- a/Source/Krypton Toolkit Examples/SystemThemedForms/Program.cs
+++ b/Source/Krypton Toolkit Examples/SystemThemedForms/Program.cs
@@ -1,6 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
 
 namespace SystemThemedForms

--- a/Source/Krypton Toolkit Examples/SystemThemedForms/SystemThemedForms 2019.csproj
+++ b/Source/Krypton Toolkit Examples/SystemThemedForms/SystemThemedForms 2019.csproj
@@ -36,10 +36,6 @@
     <ApplicationIcon>Resources\Krypton.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -82,6 +78,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Krypton.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj">
+      <Project>{96ecaecc-54f8-4aa5-8591-b443c2d9565f}</Project>
+      <Name>ComponentFactory.Krypton.Toolkit 2019</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Krypton Toolkit Examples/Test Clip Base/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test Clip Base/Form1.cs
@@ -1,4 +1,11 @@
-﻿using System.Windows.Forms;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System.Windows.Forms;
 
 namespace Test_Clip_Base
 {

--- a/Source/Krypton Toolkit Examples/Test Clip Base/Program.cs
+++ b/Source/Krypton Toolkit Examples/Test Clip Base/Program.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
 
 namespace Test_Clip_Base

--- a/Source/Krypton Toolkit Examples/Test Clip Base/Test Clip Base 2019.csproj
+++ b/Source/Krypton Toolkit Examples/Test Clip Base/Test Clip Base 2019.csproj
@@ -39,10 +39,6 @@
     <ApplicationIcon>Resources\Krypton.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -88,6 +84,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Krypton.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj">
+      <Project>{96ecaecc-54f8-4aa5-8591-b443c2d9565f}</Project>
+      <Name>ComponentFactory.Krypton.Toolkit 2019</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.cs
@@ -1,6 +1,14 @@
-﻿using ComponentFactory.Krypton.Toolkit;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
 using System;
 using System.Windows.Forms;
+
+using ComponentFactory.Krypton.Toolkit;
 
 namespace TestMessageBoxClipping
 {

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Program.cs
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Program.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
 
 using ComponentFactory.Krypton.Toolkit;

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Test MessageBox Clipping 2019.csproj
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Test MessageBox Clipping 2019.csproj
@@ -39,10 +39,6 @@
     <ApplicationIcon>Resources\Krypton.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -85,6 +81,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Krypton.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj">
+      <Project>{96ecaecc-54f8-4aa5-8591-b443c2d9565f}</Project>
+      <Name>ComponentFactory.Krypton.Toolkit 2019</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.Designer.cs
@@ -1,4 +1,4 @@
-namespace ThreePaneApplication
+namespace TestTextClipping
 {
     partial class Form1
     {

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
@@ -1,18 +1,16 @@
 ﻿// *****************************************************************************
-// 
-//  © Component Factory Pty Ltd 2012 - 2019. All rights reserved.
-//	The software and associated documentation supplied hereunder are the 
-//  proprietary information of Component Factory Pty Ltd, PO Box 1504, 
-//  Glen Waverley, Vic 3150, Australia and are supplied subject to licence terms.
-// 
-//  Version 5.470.0.0 	www.ComponentFactory.com
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
 // *****************************************************************************
 
 using System;
 using System.Windows.Forms;
+
 using ComponentFactory.Krypton.Toolkit;
 
-namespace ThreePaneApplication
+namespace TestTextClipping
 {
     public partial class Form1 : KryptonForm
     {

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Program.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Program.cs
@@ -1,17 +1,15 @@
 ﻿// *****************************************************************************
-// 
-//  © Component Factory Pty Ltd 2012 - 2019. All rights reserved.
-//	The software and associated documentation supplied hereunder are the 
-//  proprietary information of Component Factory Pty Ltd, PO Box 1504, 
-//  Glen Waverley, Vic 3150, Australia and are supplied subject to licence terms.
-// 
-//  Version 5.470.0.0 	www.ComponentFactory.com
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
+//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
 // *****************************************************************************
+
 
 using System;
 using System.Windows.Forms;
 
-namespace ThreePaneApplication
+namespace TestTextClipping
 {
     static class Program
     {

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Test Text Clipping 2019.csproj
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Test Text Clipping 2019.csproj
@@ -57,10 +57,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Krypton Toolkit, Version=5.470.872.0, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Bin\Krypton Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
@@ -102,6 +98,12 @@
   <ItemGroup>
     <Content Include="Krypton.ico" />
     <None Include="Resources\Databar_gradient_pink_32.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Krypton Components\ComponentFactory.Krypton.Toolkit\ComponentFactory.Krypton.Toolkit 2019.csproj">
+      <Project>{96ecaecc-54f8-4aa5-8591-b443c2d9565f}</Project>
+      <Name>ComponentFactory.Krypton.Toolkit 2019</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Fix #167 : KryptonContextMenu in KryptonTreeView is not obvious and not designer friendly 
- Update the Demo Application
- Change the description text for the ContextMenu
- Add Krypton Context Menu to the treeview