### PR TITLE
Fix #179: KryptonTreeView with CheckBox and Image does not leave a "Gap"

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -323,6 +323,8 @@ namespace ComponentFactory.Krypton.Toolkit
         private readonly ViewDrawButton _drawButton;
         private readonly ViewDrawCheckBox _drawCheckBox;
         private readonly ViewLayoutCenter _layoutCheckBox;
+        private readonly ViewLayoutSeparator _layoutCheckBoxAfter;
+        private readonly ViewLayoutStack _layoutCheckBoxStack;
         private readonly ViewLayoutDocker _layoutDocker;
         private readonly ViewLayoutStack _layoutImageStack;
         private readonly ViewLayoutCenter _layoutImageCenter;
@@ -576,6 +578,12 @@ namespace ComponentFactory.Krypton.Toolkit
             {
                 _drawCheckBox
             };
+            _layoutCheckBoxAfter = new ViewLayoutSeparator(3, 0);
+            _layoutCheckBoxStack = new ViewLayoutStack(true)
+            {
+                _layoutCheckBox,
+                _layoutCheckBoxAfter
+            };
 
             // Stack used to layout the location of the node image
             _layoutImage = new ViewLayoutSeparator(0, 0);
@@ -603,7 +611,7 @@ namespace ComponentFactory.Krypton.Toolkit
             {
                 { _layoutImageStack, ViewDockStyle.Left },
                 { _layoutImageCenterState, ViewDockStyle.Left },
-                { _layoutCheckBox, ViewDockStyle.Left },
+                { _layoutCheckBoxStack, ViewDockStyle.Left },
                 { _drawButton, ViewDockStyle.Fill }
             };
 
@@ -1928,10 +1936,10 @@ namespace ComponentFactory.Krypton.Toolkit
             _layoutImageCenterState.Visible = (drawStateImage != null);
 
             // Do we need the check box?
-            _layoutCheckBox.Visible = (StateImageList == null) 
+            _layoutCheckBoxStack.Visible = (StateImageList == null) 
                                       && CheckBoxes 
                                       && (kryptonNode?.IsCheckBoxVisible != false);
-            if (_layoutCheckBox.Visible)
+            if (_layoutCheckBoxStack.Visible)
             {
                 _drawCheckBox.CheckState = e.Node.Checked ? CheckState.Checked : CheckState.Unchecked;
             }

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.1102.0")]
-[assembly: AssemblyFileVersion("5.470.1102.0")]
-[assembly: AssemblyInformationalVersion("5.470.1102.0")]
+[assembly: AssemblyVersion("5.470.1103.0")]
+[assembly: AssemblyFileVersion("5.470.1103.0")]
+[assembly: AssemblyInformationalVersion("5.470.1103.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Toolkit")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Toolkit.dll")]


### PR DESCRIPTION
- Add Stack to CheckBox display (ala imageStack)