### PR TITLE
Fix #187: KryptonComboBox does not support "Simple Style" and throws exception in Designer 

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ComponentFactory.Krypton.Toolkit 2019.csproj
@@ -128,7 +128,20 @@
     <Compile Include="Controller\MenuItemController.cs" />
     <Compile Include="Controller\RadioButtonController.cs" />
     <Compile Include="Controls Visuals\VisualShadowBase.cs" />
+    <Compile Include="Designers\KryptonCheckButtonCollectionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Designers\KryptonCheckButtonCollectionForm.Designer.cs">
+      <DependentUpon>KryptonCheckButtonCollectionForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Designers\KryptonContextMenuCollectionForm.cs" />
+    <Compile Include="Designers\OverrideComboBoxStyleDropDownStyle.cs" />
+    <Compile Include="Designers\PaletteDrawBordersSelector.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Designers\PaletteDrawBordersSelector.Designer.cs">
+      <DependentUpon>PaletteDrawBordersSelector.cs</DependentUpon>
+    </Compile>
     <Compile Include="EventArgs\DataGridViewButtonSpecClickEventArgs.cs" />
     <Compile Include="Controls Toolkit\KryptonByteViewer.cs">
       <SubType>Component</SubType>
@@ -542,10 +555,6 @@
     <Compile Include="Designers\KryptonCheckBoxDesigner.cs" />
     <Compile Include="Designers\KryptonCheckButtonActionList.cs" />
     <Compile Include="Designers\KryptonCheckButtonCollectionEditor.cs" />
-    <Compile Include="Designers\KryptonCheckButtonCollectionForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Include="Designers\KryptonCheckButtonCollectionForm.Designer.cs" />
     <Compile Include="Designers\KryptonCheckButtonDesigner.cs" />
     <Compile Include="Designers\KryptonCheckedListBoxActionList.cs" />
     <Compile Include="Designers\KryptonCheckedListBoxDesigner.cs" />
@@ -624,13 +633,8 @@
     <Compile Include="Designers\KryptonWrapLabelActionList.cs" />
     <Compile Include="Designers\KryptonWrapLabelDesigner.cs" />
     <Compile Include="Designers\PaletteDrawBordersEditor.cs" />
-    <Compile Include="Designers\PaletteDrawBordersSelector.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Include="Designers\PaletteDrawBordersSelector.Designer.cs" />
     <Compile Include="Utilities\PaletteImageScaler.cs" />
-    <Compile Include="Values\CheckBoxImages.cs">
-    </Compile>
+    <Compile Include="Values\CheckBoxImages.cs" />
     <Compile Include="Palette Controls\PaletteHeaderButtonRedirect.cs" />
     <Compile Include="Palette Controls\PaletteFormRedirect.cs" />
     <Compile Include="Palette Controls\PaletteForm.cs" />
@@ -929,13 +933,17 @@
     <EmbeddedResource Include="Controls Toolkit\KryptonMessageBox.resx">
       <DependentUpon>KryptonMessageBox.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Designers\KryptonCheckButtonCollectionForm.resx">
+      <DependentUpon>KryptonCheckButtonCollectionForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Designers\PaletteDrawBordersSelector.resx">
+      <DependentUpon>PaletteDrawBordersSelector.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <SubType>Designer</SubType>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="Designers\KryptonCheckButtonCollectionForm.resx" />
-    <EmbeddedResource Include="Designers\PaletteDrawBordersSelector.resx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.manifest" />
@@ -1390,7 +1398,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_StartDate="2000/1/1" DocumentXCommentEditorState="&lt;HtmlEditState&gt;&#xA;  &lt;Attributes /&gt;&#xA;&lt;/HtmlEditState&gt;" />
+      <UserProperties DocumentXCommentEditorState="&lt;HtmlEditState&gt;&#xA;  &lt;Attributes /&gt;&#xA;&lt;/HtmlEditState&gt;" BuildVersion_StartDate="2000/1/1" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
@@ -19,7 +19,7 @@ namespace ComponentFactory.Krypton.Toolkit
     /// <summary>
     /// Manage the items that can be added to a top level context menu collection.
     /// </summary>
-    [Editor(typeof(ComponentFactory.Krypton.Toolkit.KryptonContextMenuCollectionEditor), typeof(UITypeEditor))]
+    [Editor(typeof(KryptonContextMenuCollectionEditor), typeof(UITypeEditor))]
     public class KryptonContextMenuCollection : TypedRestrictCollection<KryptonContextMenuItemBase>
     {
         #region Static Fields

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -22,7 +22,7 @@ namespace ComponentFactory.Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuItem), "ToolboxBitmaps.KryptonContextMenuItem.bmp")]
-    [Designer(typeof(ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemDesigner))]
+    [Designer(typeof(KryptonContextMenuItemDesigner))]
     [DesignerCategory("code")]
     [DesignTimeVisible(false)]
     [DefaultProperty("Text")]
@@ -557,7 +557,7 @@ namespace ComponentFactory.Krypton.Toolkit
         [Category("Data")]
         [Description("Collection of sub-menu items.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [Editor(typeof(ComponentFactory.Krypton.Toolkit.KryptonContextMenuCollectionEditor), typeof(UITypeEditor))]
+        [Editor(typeof(KryptonContextMenuCollectionEditor), typeof(UITypeEditor))]
         public KryptonContextMenuCollection Items { get; }
 
         /// <summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
@@ -21,7 +21,7 @@ namespace ComponentFactory.Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuItems), "ToolboxBitmaps.KryptonContextMenuItems.bmp")]
-    [Designer(typeof(ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemsDesigner))]
+    [Designer(typeof(KryptonContextMenuItemsDesigner))]
     [DesignerCategory("code")]
     [DesignTimeVisible(false)]
     [DefaultProperty("Items")]
@@ -130,7 +130,7 @@ namespace ComponentFactory.Krypton.Toolkit
         [Category("Data")]
         [Description("Collection of standard menu items.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [Editor(typeof(ComponentFactory.Krypton.Toolkit.KryptonContextMenuItemCollectionEditor), typeof(UITypeEditor))]
+        [Editor(typeof(KryptonContextMenuItemCollectionEditor), typeof(UITypeEditor))]
         public KryptonContextMenuItemCollection Items { get; }
 
         /// <summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controller/SeparatorController.cs
@@ -860,7 +860,7 @@ namespace ComponentFactory.Krypton.Toolkit
             public void ShowWithoutActivate()
             {
                 // Show the window without activating it (i.e. do not take focus)
-                PI.ShowWindow(this.Handle, PI.ShowWindowCommands.SW_SHOWNOACTIVATE);
+                PI.ShowWindow(Handle, PI.ShowWindowCommands.SW_SHOWNOACTIVATE);
             }
 
             /// <summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1543,6 +1543,7 @@ namespace ComponentFactory.Krypton.Toolkit
         /// </summary>
         [Category("Appearance")]
         [Description("Controls the appearance and functionality of the KryptonComboBox.")]
+        [Editor(typeof(OverrideComboBoxStyleDropDownStyle), typeof(UITypeEditor))]
         [DefaultValue(typeof(ComboBoxStyle), "DropDown")]
         [RefreshProperties(RefreshProperties.Repaint)]
         public ComboBoxStyle DropDownStyle

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewBinaryColumn.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewBinaryColumn.cs
@@ -59,9 +59,9 @@ namespace ComponentFactory.Krypton.Toolkit
         {
             StringBuilder builder = new StringBuilder(0x40);
             builder.Append("KryptonDataGridViewBinaryColumn { Name=");
-            builder.Append(base.Name);
+            builder.Append(Name);
             builder.Append(", Index=");
-            builder.Append(base.Index.ToString(CultureInfo.CurrentCulture));
+            builder.Append(Index.ToString(CultureInfo.CurrentCulture));
             builder.Append(" }");
             return builder.ToString();
         }

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1141,8 +1141,8 @@ namespace ComponentFactory.Krypton.Toolkit
                 mmi.ptMaxPosition.Y = Math.Abs(rcWorkArea.top - rcMonitorArea.top);
                 mmi.ptMaxSize.X = Math.Abs(rcWorkArea.right - rcWorkArea.left);
                 mmi.ptMaxSize.Y = Math.Abs(rcWorkArea.bottom - rcWorkArea.top);
-                mmi.ptMinTrackSize.X = Math.Max(mmi.ptMinTrackSize.X*2, this.MinimumSize.Width);
-                mmi.ptMinTrackSize.Y = Math.Max(mmi.ptMinTrackSize.Y*2, this.MinimumSize.Height);
+                mmi.ptMinTrackSize.X = Math.Max(mmi.ptMinTrackSize.X*2, MinimumSize.Width);
+                mmi.ptMinTrackSize.Y = Math.Max(mmi.ptMinTrackSize.Y*2, MinimumSize.Height);
             }
 
             Marshal.StructureToPtr(mmi, m.LParam, true);

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Designers/OverrideComboBoxStyleDropDownStyle.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Designers/OverrideComboBoxStyleDropDownStyle.cs
@@ -1,0 +1,51 @@
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  Created by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2019 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace ComponentFactory.Krypton.Toolkit
+{
+    internal class OverrideComboBoxStyleDropDownStyle : UITypeEditor
+    {
+        /// <summary>
+        /// Gets the editor style used by the EditValue method.
+        /// </summary>
+        /// <param name="context">An ITypeDescriptorContext that can be used to gain additional context information.</param>
+        /// <returns>UITypeEditorEditStyle value.</returns>
+        /// <remarks>
+        /// We show a drop down for editing the PaletteDrawBorders value.
+        /// </remarks>
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => context?.Instance != null
+            ? UITypeEditorEditStyle.DropDown
+            : base.GetEditStyle(context);
+
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            IWindowsFormsEditorService svc = (IWindowsFormsEditorService)provider?.GetService(typeof(IWindowsFormsEditorService));
+            if (svc != null)
+            {
+                UserControl ctrl = new UserControl();
+                ListBox clb = new ListBox { Dock = DockStyle.Fill };
+                clb.Items.Add(ComboBoxStyle.DropDown);
+                clb.Items.Add(ComboBoxStyle.DropDownList);
+                clb.SelectedIndexChanged += delegate 
+                    {
+                        value = Enum.Parse(typeof(ComboBoxStyle), clb.SelectedItem.ToString());
+                        svc.CloseDropDown();
+                    };
+                ctrl.Controls.Add(clb);
+                svc.DropDownControl(ctrl);
+            }
+
+            return value;
+        }
+    }
+}

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -210,7 +210,7 @@ namespace ComponentFactory.Krypton.Toolkit
         [Description("Specify which borders should be drawn.")]
         [DefaultValue(typeof(PaletteDrawBorders), "Inherit")]
         [RefreshPropertiesAttribute(RefreshProperties.All)]
-        [Editor(typeof(ComponentFactory.Krypton.Toolkit.PaletteDrawBordersEditor), typeof(UITypeEditor))]
+        [Editor(typeof(PaletteDrawBordersEditor), typeof(UITypeEditor))]
         public PaletteDrawBorders DrawBorders
         {
             get => _storage?.BorderDrawBorders ?? PaletteDrawBorders.Inherit;

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Palette Builtin/PaletteOffice365Black.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Palette Builtin/PaletteOffice365Black.cs
@@ -22,18 +22,18 @@ namespace ComponentFactory.Krypton.Toolkit
         private static readonly ImageList _checkBoxList;
         private static readonly ImageList _galleryButtonList;
         private static readonly Image[] _radioButtonArray;
-        private static readonly Image _blackDropDownButton = Properties.Resources._2010BlackDropDownButton;
-        private static readonly Image _contextMenuSubMenu = Properties.Resources._2010BlackContextMenuSub;
-        private static readonly Image _formCloseH = Properties.Resources._2010ButtonCloseH;
-        private static readonly Image _formClose = Properties.Resources._2010ButtonCloseBlack;
-        private static readonly Image _formMax = Properties.Resources._2010ButtonMaxBlack;
-        private static readonly Image _formMin = Properties.Resources._2010ButtonMinBlack;
-        private static readonly Image _formRestore = Properties.Resources._2010ButtonRestore;
-        private static readonly Image _buttonSpecPendantClose = Properties.Resources._2010ButtonMDICloseBlack;
-        private static readonly Image _buttonSpecPendantMin = Properties.Resources._2010ButtonMDIMinBlack;
-        private static readonly Image _buttonSpecPendantRestore = Properties.Resources._2010ButtonMDIRestoreBlack;
-        private static readonly Image _buttonSpecRibbonMinimize = Properties.Resources.RibbonUp2010Black;
-        private static readonly Image _buttonSpecRibbonExpand = Properties.Resources.RibbonDown2010Black;
+        private static readonly Image _blackDropDownButton = Resources._2010BlackDropDownButton;
+        private static readonly Image _contextMenuSubMenu = Resources._2010BlackContextMenuSub;
+        private static readonly Image _formCloseH = Resources._2010ButtonCloseH;
+        private static readonly Image _formClose = Resources._2010ButtonCloseBlack;
+        private static readonly Image _formMax = Resources._2010ButtonMaxBlack;
+        private static readonly Image _formMin = Resources._2010ButtonMinBlack;
+        private static readonly Image _formRestore = Resources._2010ButtonRestore;
+        private static readonly Image _buttonSpecPendantClose = Resources._2010ButtonMDICloseBlack;
+        private static readonly Image _buttonSpecPendantMin = Resources._2010ButtonMDIMinBlack;
+        private static readonly Image _buttonSpecPendantRestore = Resources._2010ButtonMDIRestoreBlack;
+        private static readonly Image _buttonSpecRibbonMinimize = Resources.RibbonUp2010Black;
+        private static readonly Image _buttonSpecRibbonExpand = Resources.RibbonDown2010Black;
         private static readonly Color _disabledRibbonText = Color.FromArgb(205, 205, 205);
         private static readonly Color[] _trackBarColors = { Color.FromArgb( 17,  17,  17),      // Tick marks
                                                                         Color.FromArgb( 37,  37,  37),      // Top track
@@ -292,14 +292,14 @@ namespace ComponentFactory.Krypton.Toolkit
 
             _galleryButtonList.Images.AddStrip(Resources.Gallery2010);
 
-            _radioButtonArray = new Image[]{Properties.Resources.RB2010BlueD,
-                                            Properties.Resources.RB2010SilverN,
-                                            Properties.Resources.RB2010BlueT,
-                                            Properties.Resources.RB2010BlueP,
-                                            Properties.Resources.RB2010BlueDC,
-                                            Properties.Resources.RB2010SilverNC,
-                                            Properties.Resources.RB2010SilverTC,
-                                            Properties.Resources.RB2010SilverPC};
+            _radioButtonArray = new Image[]{Resources.RB2010BlueD,
+                                            Resources.RB2010SilverN,
+                                            Resources.RB2010BlueT,
+                                            Resources.RB2010BlueP,
+                                            Resources.RB2010BlueDC,
+                                            Resources.RB2010SilverNC,
+                                            Resources.RB2010SilverTC,
+                                            Resources.RB2010SilverPC};
         }
 
         /// <summary>

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.1199.0")]
-[assembly: AssemblyFileVersion("5.470.1199.0")]
-[assembly: AssemblyInformationalVersion("5.470.1199.0")]
+[assembly: AssemblyVersion("5.470.1204.0")]
+[assembly: AssemblyFileVersion("5.470.1204.0")]
+[assembly: AssemblyInformationalVersion("5.470.1204.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Toolkit")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Toolkit.dll")]

--- a/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Form1.Designer.cs
@@ -255,7 +255,7 @@
             this.kryptonComboBox1.StateCommon.ComboBox.Content.Font = new System.Drawing.Font("Tahoma", 12F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Italic))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonComboBox1.StateCommon.ComboBox.Content.TextH = ComponentFactory.Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonComboBox1.TabIndex = 11;
-            this.kryptonComboBox1.Text = "Drop Down Enable Center";
+            this.kryptonComboBox1.Text = "Drop Down Center";
             // 
             // buttonSpecAny1
             // 

--- a/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Form1.cs
@@ -1,4 +1,10 @@
-﻿using ComponentFactory.Krypton.Toolkit;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  Created by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2019 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using ComponentFactory.Krypton.Toolkit;
 
 namespace Test_Combo_Domain_Numeric
 {

--- a/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Program.cs
+++ b/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Program.cs
@@ -1,6 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+//  Created by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2019 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Version 5.470.0.0  www.ComponentFactory.com
+// *****************************************************************************
+
+using System;
 using System.Windows.Forms;
 
 namespace Test_Combo_Domain_Numeric

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
@@ -1,7 +1,6 @@
 ﻿// *****************************************************************************
 // BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
-//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
-//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Created by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2019 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
 //  Version 5.470.0.0  www.ComponentFactory.com
 // *****************************************************************************
 

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Program.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Program.cs
@@ -1,9 +1,9 @@
 ﻿// *****************************************************************************
 // BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
-//  © Component Factory Pty Ltd, 2006-2019, All rights reserved.
-//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
+//  Created by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2019 - 2019. All rights reserved. (https://github.com/Wagnerp/Krypton-NET-5.470)
 //  Version 5.470.0.0  www.ComponentFactory.com
 // *****************************************************************************
+
 
 
 using System;


### PR DESCRIPTION
Fix #187: KryptonComboBox does not support "Simple Style" and throws exception in Designer 
- Add editor control over the Available options
- Remove some un-needed `this` style references