### PR TITLE
Prevent crash when a form is disposed immediately during closing

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/ShadowManager.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/General/ShadowManager.cs
@@ -389,20 +389,35 @@ namespace ComponentFactory.Krypton.Toolkit
                 throw new ArgumentException("Cannot use disposed form.");
             }
 
+            void OnHandleKnown()
+            {
+                // hold the handle here to unregister it without depending on the form
+                var handle = f.Handle;
+                _forms[handle] = f;
+                f.Closing += delegate { Unregister(handle); };
+            }
+
             if (f.Handle == IntPtr.Zero)
             {
-                f.HandleCreated += delegate { _forms[f.Handle] = f; };
+                f.HandleCreated += delegate { OnHandleKnown(); };
             }
             else
             {
-                _forms[f.Handle] = f;
+                OnHandleKnown();
             }
+        }
 
-            f.Closing += delegate { Unregister(f); };
+        internal static void Unregister(IntPtr handle)
+        {
+            if (handle != null)
+            {
+                _forms.Remove(handle);
+            }
         }
 
         internal static void Unregister(Form f)
         {
+            // This will crash if f has been disposed
             if (f.Handle != null)
             {
                 _forms.Remove(f.Handle);


### PR DESCRIPTION
Hello,

When the `DefaultCloseRequest` property of the `KryptonDockingManager` is set to `RemovePageAndDispose`, closing a floating window crashes the application.

Steps to reproduce: in the "Navigator + FloatingWindows 2019" example (from Krypton Docking examples), set the `DockingAllowClose` flag of the new pages to allow the user to close them, set the `DefaultCloseRequest` property of the `KryptonDockingManager` to `RemovePageAndDispose`, then run the project and close a floating window.

The same issue can occur when a floating window is disposing immediately at closing, even if a different `DefaultCloseRequest` is used.

This issue is caused by the `ShadowManager.FlashWindowExListener` class which does not expect the window to be possibly disposed before the `Closing` event is fired. It tries to access the `Handle` property of the window to remove it from its internal list of forms, however that property cannot be accessed after the window has been disposed and that causes a crash.

The fix is to adapt its `Closing` event handler to use the window's handle directly (stored in a closure) rather than a reference to the window.