### PR TITLE
Fix exception when saving workspace state and a page has no tag

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
@@ -2228,7 +2228,7 @@ namespace ComponentFactory.Krypton.Workspace
 
             //Seb
             //TODO store object instead of strings
-            CommonHelper.TextToXmlAttribute(xmlWriter, @"TAG", page.Tag.ToString());
+            CommonHelper.TextToXmlAttribute(xmlWriter, @"TAG", page.Tag?.ToString());
             //End Seb
 
             // Write out images as child elements
@@ -2291,7 +2291,7 @@ namespace ComponentFactory.Krypton.Workspace
                 page.Flags = int.Parse(CommonHelper.XmlAttributeToText(xmlReader, @"F", page.Flags.ToString()));
 
                 //Seb
-                page.Tag = CommonHelper.XmlAttributeToText(xmlReader, @"TAG");
+                page.Tag = CommonHelper.XmlAttributeToText(xmlReader, @"TAG", null);
                 //End Seb
             }
 


### PR DESCRIPTION
When at least one of the pages in a workspace does not have its `Tag` property set, saving the state of the workspace fails (a `NullReferenceException` is raised). The fix is to avoid writing a tag value in the output when there is no value to write.