### PR TITLE
- Investigate #211: ComboBox Design Time Spacing

### DIFF
--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2111,7 +2111,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -1535,7 +1535,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1428,7 +1428,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -257,7 +257,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -530,7 +530,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -696,7 +696,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1387,7 +1387,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1533,7 +1533,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1724,7 +1724,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1305,7 +1305,7 @@ namespace ComponentFactory.Krypton.Toolkit
             // Do we have a manager to ask for a preferred size?
             if (ViewManager != null)
             {
-                // Ask the view to peform a layout
+                // Ask the view to perform a layout
                 Size retSize = ViewManager.GetPreferredSize(Renderer, proposedSize);
 
                 // Apply the maximum sizing
@@ -1316,7 +1316,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualSimple.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualSimple.cs
@@ -87,7 +87,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -87,7 +87,7 @@ namespace ComponentFactory.Krypton.Toolkit
 
                 if (MaximumSize.Height > 0)
                 {
-                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Width);
+                    retSize.Height = Math.Min(MaximumSize.Height, retSize.Height);
                 }
 
                 // Apply the minimum sizing

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Designers/KryptonTextBoxDesigner.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Designers/KryptonTextBoxDesigner.cs
@@ -81,7 +81,7 @@ namespace ComponentFactory.Krypton.Toolkit
                 // Get access to the actual control instance
                 KryptonTextBox textBox = (KryptonTextBox)Component;
 
-                // With multiline and autosize we prevent the user changing the height
+                // With multiline or autosize we prevent the user changing the height
                 if (!textBox.Multiline && textBox.AutoSize)
                 {
                     rules &= ~(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);

--- a/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
+++ b/Source/Krypton Components/ComponentFactory.Krypton.Toolkit/Properties/AssemblyInfo.cs
@@ -16,9 +16,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-[assembly: AssemblyVersion("5.470.2074.0")]
-[assembly: AssemblyFileVersion("5.470.2074.0")]
-[assembly: AssemblyInformationalVersion("5.470.1337.0")]
+[assembly: AssemblyVersion("5.470.2083.0")]
+[assembly: AssemblyFileVersion("5.470.2083.0")]
+[assembly: AssemblyInformationalVersion("5.470.1346.0")]
 [assembly: AssemblyCopyright("© Component Factory Pty Ltd, 2006-2019. Then modifications by Peter Wagner (aka Wagnerp) & Simon Coghlan (aka Smurf-IV) 2017-2019. All rights reserved.")]
 [assembly: AssemblyProduct("Krypton Toolkit")]
 [assembly: AssemblyDefaultAlias("ComponentFactory.Krypton.Toolkit.dll")]


### PR DESCRIPTION
- Seems related to the default size being returned to the `PreferredHeight` call, which eventually goes into the Winform:Control base class to determine what shoud be returned
- Therefore there is no _easy_ way to alter this functionality as it will be down to the fonts used by the Theme and Windows Font scaling in use at runtime.
- Did fix the checks when using MaximumSize's for the other control.